### PR TITLE
Release: Additional Logging, Added Typings for Matrix Event Dispatcher

### DIFF
--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alkemio-matrix-adapter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "alkemio-matrix-adapter",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/matrix-adapter-lib": "^0.2.1",

--- a/service/package.json
+++ b/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alkemio-matrix-adapter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Alkemio Matrix Adapter service",
   "author": "Alkemio Foundation",
   "private": false,

--- a/service/src/common/enums/synapse.endpoint.ts
+++ b/service/src/common/enums/synapse.endpoint.ts
@@ -1,3 +1,4 @@
 export enum SynapseEndpoint {
   REGISTRATION = '/_synapse/admin/v1/register',
+  SERVER_VERSION = '/_synapse/admin/v1/server_version',
 }

--- a/service/src/core/bootstrap/bootstrap.module.ts
+++ b/service/src/core/bootstrap/bootstrap.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { BootstrapService } from './bootstrap.service';
+import { CommunicationAdapterModule } from '@src/services/communication-adapter/communication-adapter.module';
 
 @Module({
-  imports: [],
+  imports: [CommunicationAdapterModule],
   providers: [BootstrapService],
   exports: [BootstrapService],
 })

--- a/service/src/core/bootstrap/bootstrap.service.ts
+++ b/service/src/core/bootstrap/bootstrap.service.ts
@@ -3,11 +3,13 @@ import { ConfigService } from '@nestjs/config';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ConfigurationTypes, LogContext } from '@common/enums';
 import { BootstrapException } from '@src/common/exceptions/bootstrap.exception';
+import { CommunicationAdapter } from '@src/services/communication-adapter/communication.adapter';
 
 @Injectable()
 export class BootstrapService {
   constructor(
     private configService: ConfigService,
+    private communicationAdapter: CommunicationAdapter,
     @Inject(WINSTON_MODULE_NEST_PROVIDER)
     private readonly logger: LoggerService
   ) {}
@@ -19,6 +21,7 @@ export class BootstrapService {
         LogContext.BOOTSTRAP
       );
       this.logConfiguration();
+      await this.communicationAdapter.initiateMatrixConnection();
     } catch (error: any) {
       throw new BootstrapException(error.message);
     }

--- a/service/src/services/communication-adapter/communication.adapter.ts
+++ b/service/src/services/communication-adapter/communication.adapter.ts
@@ -55,6 +55,15 @@ export class CommunicationAdapter {
     this.enabled = true;
   }
 
+  public async initiateMatrixConnection() {
+    await this.logServerVersion();
+    this.logger.verbose?.(
+      `Matrix admin identifier: ${this.adminCommunicationsID}`,
+      LogContext.BOOTSTRAP
+    );
+    await this.getMatrixManagementAgentElevated();
+  }
+
   async sendMessage(
     sendMessageData: RoomSendMessagePayload
   ): Promise<IMessage> {
@@ -239,6 +248,21 @@ export class CommunicationAdapter {
     });
 
     return this.matrixElevatedAgent;
+  }
+
+  private async logServerVersion() {
+    try {
+      const version = await this.matrixUserManagementService.getServerVersion();
+      this.logger.verbose?.(
+        `Synapse server version: ${version}`,
+        LogContext.BOOTSTRAP
+      );
+    } catch (error: any) {
+      this.logger.verbose?.(
+        `Unable to get synapse server version: ${error}`,
+        LogContext.BOOTSTRAP
+      );
+    }
   }
 
   private async registerNewAdminUser(): Promise<IOperationalMatrixUser> {

--- a/service/src/services/matrix/events/matrix.event.dispatcher.ts
+++ b/service/src/services/matrix/events/matrix.event.dispatcher.ts
@@ -1,6 +1,13 @@
 import { Disposable } from '@src/common/interfaces/disposable.interface';
 import { EventEmitter } from 'events';
-import { MatrixClient, MatrixEvent } from 'matrix-js-sdk';
+import {
+  ClientEvent,
+  EmittedEvents,
+  MatrixClient,
+  MatrixEvent,
+  RoomEvent,
+  RoomMemberEvent,
+} from 'matrix-js-sdk';
 import { first, fromEvent, Observable, Observer, Subscription } from 'rxjs';
 import { MatrixRoom } from '../adapter-room/matrix.room';
 import { MatrixEventHandler } from '../types/matrix.event.handler.type';
@@ -52,25 +59,27 @@ export class MatrixEventDispatcher
 
   private init() {
     this.initMonitor<{ syncState: string; oldSyncState: string }>(
-      'sync',
+      ClientEvent.Sync,
       'syncMonitor',
       this._syncMonitor
     );
-    this.initMonitor<any>('Room', 'roomMonitor', this._roomMonitor);
+    this.initMonitor<any>(ClientEvent.Room, 'roomMonitor', this._roomMonitor);
+
     this.initMonitor<RoomTimelineEvent>(
-      'Room.timeline',
+      RoomEvent.Timeline,
       'roomTimelineMonitor',
       this._roomTimelineMonitor
     );
+
     this.initMonitor<{ event: any; member: any }>(
-      'RoomMember.membership',
+      RoomMemberEvent.Membership,
       'roomMemberMembershipMonitor',
       this._roomMemberMembershipMonitor
     );
   }
 
   private initMonitor<T>(
-    event: any,
+    event: EmittedEvents,
     handler: keyof IMatrixEventDispatcher,
     monitor: MatrixEventHandler
   ) {

--- a/service/src/services/matrix/management/matrix.user.management.service.ts
+++ b/service/src/services/matrix/management/matrix.user.management.service.ts
@@ -46,6 +46,21 @@ export class MatrixUserManagementService {
     });
   }
 
+  public async getServerVersion(): Promise<string> {
+    const url = new URL(SynapseEndpoint.SERVER_VERSION, this.baseUrl);
+    const response = await this.httpService
+      .get<{ server_version: string }>(url.href)
+      .toPromise();
+    if (!response)
+      throw new MatrixUserRegistrationException(
+        'Invalid response!',
+        LogContext.COMMUNICATION
+      );
+
+    const version = response.data['server_version'];
+    return JSON.stringify(version);
+  }
+
   async register(
     matrixUserID: string,
     password?: string,


### PR DESCRIPTION
## Logging
  - Added loggin of `Synapse` server version when starting the service

## Dev
  - Refactored `MatrixEventDispatcher` to be strongly typed and not use `any` for `initMonitor`